### PR TITLE
Readme: A very small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An R client for the BAN API
 
 [![Travis-CI Build Status](https://travis-ci.org/joelgombin/banR.svg?branch=master)](https://travis-ci.org/joelgombin/banR)
 
-The `banR` package is a light R client for the [BAN API](https://adresse.data.gouv.fr/api/). The [Base Adresse Nationale (BAN)](https://adresse.data.gouv.fr/) is an open database of French adresses, produced by OpenStreetMap, La Poste, the IGN and Etalab.
+The `banR` package is a light R client for the [BAN API](https://adresse.data.gouv.fr/api). The [Base Adresse Nationale (BAN)](https://adresse.data.gouv.fr/) is an open database of French adresses, produced by OpenStreetMap, La Poste, the IGN and Etalab.
 
 `banR` can be installed from CRAN (stable version):
 


### PR DESCRIPTION
URL of the API did not work because of a `/`