### PR TITLE
change in geocode_tb and reverse to remove one warning: arg path -> f…

### DIFF
--- a/R/geocode_tbl.R
+++ b/R/geocode_tbl.R
@@ -35,7 +35,7 @@ geocode_tbl <- function(tbl, adresse, code_insee = NULL, code_postal = NULL) {
 
   dplyr::select(.data = tbl, !!! vars) %>%
     dplyr::mutate({{adresse}} := stringr::str_replace({{adresse}}, "'", " ")) %>% 
-    readr::write_csv(path = tmp)
+    readr::write_csv(file = tmp)
 
   message(
     "If file is larger than 8 MB, it must be splitted\n",
@@ -134,7 +134,7 @@ reverse_geocode_tbl <- function(tbl, longitude, latitude) {
     "latitude" = rlang::enquo(latitude)
     )
   dplyr::select(.data = tbl, !!! vars) %>%
-    readr::write_csv(path = tmp)
+    readr::write_csv(file = tmp)
 
   tbl_temp <- dplyr::select(
     .data = tbl,


### PR DESCRIPTION
Bonjour, 

Merci beaucoup pour le package! 

C'est un tout petit changement suivant readr 1.4 modifiant l'argument `path` par `file` (https://www.tidyverse.org/blog/2020/10/readr-1-4-0/#argument-name-consistency).

C'etait déjà dans cette PR: https://github.com/joelgombin/banR/pull/32 

Cela gagne un message d'erreur en moins. 

