### PR TITLE
Add skip_if_offline() to all API-dependent tests

### DIFF
--- a/tests/testthat/test_geocode.R
+++ b/tests/testthat/test_geocode.R
@@ -6,6 +6,7 @@ test_that(
   desc = "Geocode works",
   code = {
     skip_on_cran()
+    skip_if_offline()
     expect_s3_class(geocode(query = "39 quai André Citroën Paris"), "tbl_df")
   }
 )
@@ -14,6 +15,7 @@ test_that(
   desc = "Reverse geocode works",
   code = {
     skip_on_cran()
+    skip_if_offline()
     expect_s3_class(reverse_geocode(long = 2.37, lat = 48.537), "tbl_df")
   }
 )

--- a/tests/testthat/test_geocodetbl.R
+++ b/tests/testthat/test_geocodetbl.R
@@ -5,6 +5,7 @@ context("Geocode tbl")
 test_that(
   "Geocode tbl works ", {
   skip_on_cran()
+  skip_if_offline()
   table_test <- tibble::tibble(
     x = c("39 quai André Citroën", "64 Allée de Bercy", "20 avenue de Ségur"),
     y = c("75015", "75012", "75007"),
@@ -23,6 +24,7 @@ test_that(
 
 test_that("Input and output DFs have a similar number of rows", {
   skip_on_cran()
+  skip_if_offline()
   # test introduit suite à issue #3
   table_test <- data.frame(
     adresses = c("11 allée Sacoman", "11 allée Sacoman", "23 allée Sacoman"),
@@ -44,6 +46,7 @@ test_that(
   desc = "Geocode_tbl works with a single-column input data.frame",
   code = {
     skip_on_cran()
+    skip_if_offline()
     table_test <- data.frame(
       city = c("Agen", "Ajaccio"),
       stringsAsFactors = FALSE
@@ -56,6 +59,7 @@ test_that(
   desc = "Reverse geocode tbl works ",
   code = {
     skip_on_cran()
+    skip_if_offline()
     table_reverse <- tibble::tibble(
       x = c(2.279092, 2.375933, 2.308332),
       y = c(48.84683, 48.84255, 48.85032),
@@ -73,6 +77,7 @@ test_that(
   desc = "Code INSEE and Code postal return the same result",
   code = {
     skip_on_cran()
+    skip_if_offline()
     table_check <- tibble::tribble(
       ~ num_voie, ~ cp,  ~ ville, ~ codecommune,
       "1 Rue Gaspard Monge", "22300", "Lannion", "22113",


### PR DESCRIPTION
This prevents timeout errors when running R CMD check locally or in CI environments where the API may be unavailable.

All tests that make network calls now have both:
- skip_on_cran(): Skip tests on CRAN infrastructure
- skip_if_offline(): Skip tests when no internet connection

This follows testthat best practices for testing code that requires internet connectivity.

Fixes test failures like:
"Timeout was reached [data.geopf.fr]: Resolving timed out after 10001 milliseconds"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add skip_if_offline() to all geocode-related tests to prevent failures without internet connectivity.
> 
> - **Tests**:
>   - Add `skip_if_offline()` to all API-dependent tests in `tests/testthat/test_geocode.R` and `tests/testthat/test_geocodetbl.R` alongside existing `skip_on_cran()`.
>   - Affects geocoding and reverse geocoding unit tests (`geocode`, `reverse_geocode`, `geocode_tbl`, `reverse_geocode_tbl`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ad795f12ba785a95cd1aed19d260c91a2b90771. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->